### PR TITLE
addition of dependencies for MacOS

### DIFF
--- a/DEPEND.md
+++ b/DEPEND.md
@@ -10,6 +10,12 @@ The following sections give the installation instructions for the required distr
 sudo apt-get install build-essential liblas-c-dev mesa-common-dev libsdl2-dev libeigen3-dev libgeographic-dev build-essential doxygen
 ```
 
+### MacOS
+```
+xcode-select --install
+brew install liblas mesa sdl2 eigen geographiclib
+```
+
 ### liberatosthene
 
 Fulfill the requirements following the [instructions](https://github.com/nils-hamel/liberatosthene).

--- a/src/dalai-vision/Makefile
+++ b/src/dalai-vision/Makefile
@@ -23,15 +23,16 @@
     MAKE_CCMP:=g++
 ifeq ($(MAKE_OSYS),Linux)
     MAKE_CLNK:=gcc-ar rcs
+    MAKE_FLNK:=-lm -lSDL2 -lGL -lGLU -flto
 else
 ifeq ($(MAKE_OSYS),Darwin)
     MAKE_CLNK:=ar -rv
+    MAKE_FLNK:=-lm -lSDL2 -framework OpenGL -flto
 endif
 endif
     MAKE_CDOC:=doxygen
 
     MAKE_FCMP:=-std=c++11 -O3 -Wall -Wno-deprecated -funsigned-char -I/usr/include/eigen3 -flto
-    MAKE_FLNK:=-lm -lSDL2 -lGL -lGLU -flto
 
 #
 #   makefile - configuration

--- a/src/dalai-vision/src/dalai-vision-model.hpp
+++ b/src/dalai-vision/src/dalai-vision-model.hpp
@@ -46,10 +46,16 @@
     # include <cstdlib>
     # include <ctime>
     # include <cmath>
-    # include <GL/gl.h>
-    # include <GL/glu.h>
     # include <common-include.hpp>
     # include <eratosthene-include.h>
+
+    #ifdef __APPLE__
+    #  include <OpenGL/gl.h>
+    #  include <OpenGL/glu.h>
+    #else
+    #  include <GL/gl.h>
+    #  include <GL/glu.h>
+    #endif
 
 /*
     header - preprocessor definitions

--- a/src/dalai-vision/src/dalai-vision-surface.hpp
+++ b/src/dalai-vision/src/dalai-vision-surface.hpp
@@ -41,11 +41,18 @@
 
     # include <iostream>
     # include <cmath>
-    # include <GL/gl.h>
-    # include <GL/glu.h>
-    # include <Eigen/Dense>
     # include <common-include.hpp>
     # include <eratosthene-include.h>
+
+    #ifdef __APPLE__
+    #  include <OpenGL/gl.h>
+    #  include <OpenGL/glu.h>
+    #  include <eigen3/Eigen/Dense>
+    #else
+    #  include <GL/gl.h>
+    #  include <GL/glu.h>
+    #  include <Eigen/Dense>
+    #endif
 
 /*
     header - preprocessor definitions

--- a/src/dalai-vision/src/dalai-vision.hpp
+++ b/src/dalai-vision/src/dalai-vision.hpp
@@ -83,11 +83,17 @@
     # include <cstdlib>
     # include <cstring>
     # include <cmath>
-    # include <GL/gl.h>
-    # include <GL/glu.h>
     # include <SDL2/SDL.h>
     # include <common-include.hpp>
     # include <eratosthene-include.h>
+
+    #ifdef __APPLE__
+    #  include <OpenGL/gl.h>
+    #  include <OpenGL/glu.h>
+    #else
+    #  include <GL/gl.h>
+    #  include <GL/glu.h>
+    #endif
 
 /*
     header - preprocessor definitions


### PR DESCRIPTION
Hi Nils,
I found the equivalent libraries for mac as those listed in DEPEND.md. 
I also had to modify stuff in src/dalai_vision/src, in the header files and in the Makefile for calling these external libraries. These modifications should be Linux friendly (normally) :)
